### PR TITLE
[WIP] DCP: Miriad output fixes

### DIFF
--- a/pyuvdata/uvdata/miriad.py
+++ b/pyuvdata/uvdata/miriad.py
@@ -1946,7 +1946,7 @@ class Miriad(UVData):
         uv.add_var("source", "a")
         uv.add_var("ra", "d")
         uv.add_var("dec", "d")
-        uv.add_var("inttime", "d")
+        uv.add_var("inttime", "r")
 
         uv.add_var("epoch", "r")
         uv.add_var("phsframe", "a")  # Non-standard MIRIAD keyword
@@ -2027,7 +2027,7 @@ class Miriad(UVData):
             this_j = self.ant_2_array[viscnt]
 
             uv["lst"] = miriad_lsts[viscnt].astype(np.double)
-            uv["inttime"] = self.integration_time[viscnt].astype(np.double)
+            uv["inttime"] = self.integration_time[viscnt].astype(np.float32)
 
             cat_id = self.phase_center_id_array[viscnt]
             uv["source"] = self.phase_center_catalog[cat_id]["cat_name"]

--- a/pyuvdata/uvdata/miriad.py
+++ b/pyuvdata/uvdata/miriad.py
@@ -1797,14 +1797,18 @@ class Miriad(UVData):
         
         # DCP 2024.01.12 - Adding defaults required for basic imaging
         #############################################################
-        for k in ("restfreq", "vsource", "veldop"):
-            uv.add_var(k, "d")
-            uv[k] = 0.0
-        
-        for k in ("jyperk", "systemp"):
-            uv.add_var(k, "r")
-            uv[k] = 1.0
-        
+        miriad_defaults = {
+            "restfreq": ("d", np.float64(0.0)),
+            "jyperk":   ("r", np.float32(1.0)),
+            "systemp":  ("r", np.float32(1.0)),
+            "veldop":   ("r", np.float32(0.0)),
+            "vsource":  ("r", np.float32(0.0))
+        }
+
+        for key, (miriad_dtype, val) in miriad_defaults.items():
+            uv.add_var(key, miriad_dtype)
+            uv[key] = val
+
         warnings.warn("writing default values for restfreq, vsource, veldop, jyperk, and systemp")
 
 

--- a/pyuvdata/uvdata/miriad.py
+++ b/pyuvdata/uvdata/miriad.py
@@ -1786,8 +1786,6 @@ class Miriad(UVData):
             # same to our tolerances
             uv["sdf"] = np.median(self.channel_width) * freq_dir / 1e9  # Hz -> GHz
 
-        # NB: restfreq should go in here at some point
-        #####################################################
         uv.add_var("telescop", "a")
         uv["telescop"] = self.telescope_name
         uv.add_var("latitud", "d")
@@ -1795,6 +1793,20 @@ class Miriad(UVData):
         uv.add_var("longitu", "d")
         uv["longitu"] = self.telescope_location_lat_lon_alt[1].astype(np.double)
         uv.add_var("nants", "i")
+        
+        
+        # DCP 2024.01.12 - Adding defaults required for basic imaging
+        #############################################################
+        for k in ("restfreq", "vsource", "veldop"):
+            uv.add_var(k, "d")
+            uv[k] = 0.0
+        
+        for k in ("jyperk", "systemp"):
+            uv.add_var(k, "r")
+            uv[k] = 1.0
+        
+        warnings.warn("writing default values for restfreq, vsource, veldop, jyperk, and systemp")
+
 
         if self.antenna_diameters is not None:
             if not np.allclose(self.antenna_diameters, self.antenna_diameters[0]):


### PR DESCRIPTION
Fixes the output type for `inttim` and adds some keywords needed for basic imaging with miriad.

## Description

This PR adds five keywords that required by miriad for imaging, with default values:  `jyperk`, `restfreq`, `vsource`, `veldop`, and `systemp`.

It also changes the data type for the `inttime` variable from double (float64) to 'real' (float32), as defined in miriad source code (see the [vartable.txt](https://github.com/pkgw/carma-miriad/blob/CVSHEAD/cat/vartable.txt)). This change fixes a runtime error that causes the miriad `invert` task to fail.

## Motivation and Context

Miriad expects `inttime` to be a 'real' (float32), however pyuvdata currently writes a float64 value. If `inttime` is not stored as a real, the miriad task `invert` will fail:

```
### Fatal Error: Variable inttime has the wrong data type, in UVREAD
```

This issue was encountered when attempting to image SKA-low data https://github.com/ska-sci-ops/aavs_uv/issues/36, and closes the issue.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md).


Version change checklist:
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/CHANGELOG.md) to put all the unreleased changes under the new version (leaving the unreleased section empty).
- [X]  (N/A): I have noted any dependency changes since the last version and will update the conda package build accordingly.

